### PR TITLE
fix: プロジェクトボリュームの権限設定を改善

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -5,8 +5,7 @@ services:
       - serena-isolated  # 隔離ネットワークに接続
     volumes:
       # 📝 PROJECT環境変数で指定されたパスをマウント
-      - ${PROJECT}:/workspace:ro  # プロジェクトをバインドマウント :ro=読み取り専用
-      - ${PROJECT}/.serena:/home/serena/.serena:rw  # プロジェクト内のSerena設定永続化
+      - ${PROJECT}:/workspace:rw  # プロジェクトをバインドマウント
     environment:
       - SERENA_DOCKER=1 # この環境変数により、Serena は Docker 環境での実行を認識し、適切な設定とパス解決を行う
     tty: true # TTYを有効にして、対話的な操作を可能にする


### PR DESCRIPTION
## Summary
- プロジェクトディレクトリのボリュームマウントを読み取り専用から読み書き可能に変更
- 不要になった個別の`.serena`ディレクトリマウント設定を削除してコンテナ設定を簡素化

## Test plan
- [x] `make up` でコンテナが正常に起動することを確認
- [x] プロジェクト内でSerenaが正常に動作することを確認
- [x] ファイル作成・編集権限が適切に設定されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)