### PR TITLE
コンテナをビルドするタイミングで、LSPサーバーをインストールするようにした

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/oraios/serena:latest
+
+# PHP言語サーバー
+RUN npm install -g intelephense@latest
+
+# JavaScript言語サーバー
+RUN npm install -g typescript-language-server@latest
+
+WORKDIR /workspaces/serena

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,6 @@
 services:
   serena:
+    build: ./
     image: ghcr.io/oraios/serena:latest  # 使用するDockerイメージ
     networks:
       - serena-isolated  # 隔離ネットワークに接続


### PR DESCRIPTION
compose up したあとは外部通信ができず `npm install` ができないので、コンテナのビルドのタイミングで LSPサーバー をインストールするようにした。